### PR TITLE
Add manual entry for company and banking details

### DIFF
--- a/src/app/api/send-invoice/route.ts
+++ b/src/app/api/send-invoice/route.ts
@@ -12,12 +12,14 @@ export async function POST(request: Request) {
       invoiceNumber,
       grandTotal,
       pdfBase64,
+      companyName,
     }: {
       to: string;
       clientName: string;
       invoiceNumber: string;
       grandTotal: number;
       pdfBase64: string;
+      companyName?: string;
     } = body;
 
     if (!to || !pdfBase64) {
@@ -43,17 +45,17 @@ export async function POST(request: Request) {
     }
 
     const fromEmail = process.env.RESEND_FROM_EMAIL || 'Invoico <onboarding@resend.dev>';
-    const companyName = process.env.COMPANY_NAME || 'JE Productions';
+    const senderCompanyName = companyName?.trim() || process.env.COMPANY_NAME || 'JE Productions';
 
     const { data, error } = await resend.emails.send({
       from: fromEmail,
       to: [to],
-      subject: `Invoice #${invoiceNumber} from ${companyName}`,
+      subject: `Invoice #${invoiceNumber} from ${senderCompanyName}`,
       html: `
         <div style="font-family: system-ui, -apple-system, sans-serif; max-width: 600px; margin: 0 auto;">
           <h2 style="color: #0f172a;">Invoice #${invoiceNumber}</h2>
           <p>Dear ${clientName || 'Valued Client'},</p>
-          <p>Please find attached your invoice #${invoiceNumber} from ${companyName}.</p>
+          <p>Please find attached your invoice #${invoiceNumber} from ${senderCompanyName}.</p>
           <p style="font-size: 18px; font-weight: 600; color: #0ea5e9;">
             Amount due: R ${grandTotal?.toLocaleString('en-ZA', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) ?? '—'}
           </p>

--- a/src/components/InvoiceForm.tsx
+++ b/src/components/InvoiceForm.tsx
@@ -14,6 +14,11 @@ import {
   Banknote,
   FileCheck,
   Send,
+  Building2,
+  Globe,
+  Hash,
+  Landmark,
+  CreditCard,
 } from 'lucide-react';
 import { Card } from './ui/Card';
 import { Input } from './ui/Input';
@@ -43,6 +48,24 @@ export default function InvoiceForm() {
     email: '',
     address: '',
     phone: '',
+  });
+
+  const [companyInfo, setCompanyInfo] = useState({
+    name: 'JE Productions',
+    tagline: 'Professional Digital Solutions',
+    email: 'abeljackson33@gmail.com',
+    address: 'Modimolle, Limpopo, South Africa',
+    phone: '+27 62 677 5823',
+    website: 'www.aj4200.dev',
+    regNo: '---',
+    vatNo: '---',
+  });
+
+  const [bankingDetails, setBankingDetails] = useState({
+    bankName: 'Capitec',
+    accountNumber: '1534094529',
+    branchCode: '470010',
+    payShapCell: '062 677 5823',
   });
 
   const [invoiceDetails, setInvoiceDetails] = useState(() => {
@@ -86,6 +109,22 @@ export default function InvoiceForm() {
     const { name, value } = e.target;
     setInvoiceDetails((prevDetails) => ({
       ...prevDetails,
+      [name]: value,
+    }));
+  };
+
+  const handleCompanyInfoChange = (e: { target: { name: string; value: string } }) => {
+    const { name, value } = e.target;
+    setCompanyInfo((prevInfo) => ({
+      ...prevInfo,
+      [name]: value,
+    }));
+  };
+
+  const handleBankingDetailsChange = (e: { target: { name: string; value: string } }) => {
+    const { name, value } = e.target;
+    setBankingDetails((prevInfo) => ({
+      ...prevInfo,
       [name]: value,
     }));
   };
@@ -158,6 +197,8 @@ export default function InvoiceForm() {
     generatePDF({
       clientInfo,
       invoiceDetails,
+      companyInfo,
+      bankingDetails,
       services,
       tax,
       notes,
@@ -187,6 +228,8 @@ export default function InvoiceForm() {
       const pdfBase64 = generatePDFAsBase64({
         clientInfo,
         invoiceDetails,
+        companyInfo,
+        bankingDetails,
         services,
         tax,
         notes,
@@ -203,6 +246,7 @@ export default function InvoiceForm() {
         body: JSON.stringify({
           to: clientInfo.email.trim(),
           clientName: clientInfo.name || 'Valued Client',
+          companyName: companyInfo.name || 'Your Company',
           invoiceNumber: invoiceDetails.invoiceNumber,
           grandTotal: calculateGrandTotal(),
           pdfBase64,
@@ -245,6 +289,144 @@ export default function InvoiceForm() {
 
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
           <div className="lg:col-span-2 space-y-6">
+            <Card variant="elevated" className="p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-10 h-10 bg-sky-100 dark:bg-sky-900/50 rounded-lg flex items-center justify-center">
+                  <Building2 className="w-5 h-5 text-sky-600 dark:text-sky-400" />
+                </div>
+                <h2 className="text-2xl font-bold text-stone-800 dark:text-stone-100">
+                  Your Company Details
+                </h2>
+              </div>
+
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <Input
+                  label="Company Name"
+                  name="name"
+                  value={companyInfo.name}
+                  onChange={handleCompanyInfoChange}
+                  placeholder="Your Company Name"
+                  icon={<Building2 className="w-4 h-4" />}
+                  required
+                />
+
+                <Input
+                  label="Tagline"
+                  name="tagline"
+                  value={companyInfo.tagline}
+                  onChange={handleCompanyInfoChange}
+                  placeholder="Professional Services"
+                  icon={<FileText className="w-4 h-4" />}
+                />
+
+                <Input
+                  label="Company Email"
+                  type="email"
+                  name="email"
+                  value={companyInfo.email}
+                  onChange={handleCompanyInfoChange}
+                  placeholder="billing@yourcompany.com"
+                  icon={<Mail className="w-4 h-4" />}
+                />
+
+                <Input
+                  label="Company Phone"
+                  type="tel"
+                  name="phone"
+                  value={companyInfo.phone}
+                  onChange={handleCompanyInfoChange}
+                  placeholder="+27 12 345 6789"
+                  icon={<Phone className="w-4 h-4" />}
+                />
+
+                <Input
+                  label="Company Address"
+                  name="address"
+                  value={companyInfo.address}
+                  onChange={handleCompanyInfoChange}
+                  placeholder="123 Main St, City"
+                  icon={<MapPin className="w-4 h-4" />}
+                />
+
+                <Input
+                  label="Website"
+                  name="website"
+                  value={companyInfo.website}
+                  onChange={handleCompanyInfoChange}
+                  placeholder="www.yourcompany.com"
+                  icon={<Globe className="w-4 h-4" />}
+                />
+
+                <Input
+                  label="Registration Number"
+                  name="regNo"
+                  value={companyInfo.regNo}
+                  onChange={handleCompanyInfoChange}
+                  placeholder="Company registration number"
+                  icon={<Hash className="w-4 h-4" />}
+                />
+
+                <Input
+                  label="VAT Number"
+                  name="vatNo"
+                  value={companyInfo.vatNo}
+                  onChange={handleCompanyInfoChange}
+                  placeholder="VAT number"
+                  icon={<Hash className="w-4 h-4" />}
+                />
+              </div>
+            </Card>
+
+            <Card variant="elevated" className="p-8">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-10 h-10 bg-sky-100 dark:bg-sky-900/50 rounded-lg flex items-center justify-center">
+                  <Landmark className="w-5 h-5 text-sky-600 dark:text-sky-400" />
+                </div>
+                <h2 className="text-2xl font-bold text-stone-800 dark:text-stone-100">
+                  Banking Details
+                </h2>
+              </div>
+
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <Input
+                  label="Bank Name"
+                  name="bankName"
+                  value={bankingDetails.bankName}
+                  onChange={handleBankingDetailsChange}
+                  placeholder="Your bank"
+                  icon={<Landmark className="w-4 h-4" />}
+                />
+
+                <Input
+                  label="Account Number"
+                  name="accountNumber"
+                  value={bankingDetails.accountNumber}
+                  onChange={handleBankingDetailsChange}
+                  placeholder="Account number"
+                  icon={<CreditCard className="w-4 h-4" />}
+                />
+
+                <Input
+                  label="Branch Code"
+                  name="branchCode"
+                  value={bankingDetails.branchCode}
+                  onChange={handleBankingDetailsChange}
+                  placeholder="Branch code"
+                  icon={<Hash className="w-4 h-4" />}
+                />
+
+                <Input
+                  label="PayShap Cell"
+                  type="tel"
+                  name="payShapCell"
+                  value={bankingDetails.payShapCell}
+                  onChange={handleBankingDetailsChange}
+                  placeholder="PayShap number"
+                  icon={<Phone className="w-4 h-4" />}
+                />
+              </div>
+            </Card>
+
             <Card variant="elevated" className="p-8">
               <div className="flex items-center gap-3 mb-6">
                 <div className="w-10 h-10 bg-sky-100 dark:bg-sky-900/50 rounded-lg flex items-center justify-center">

--- a/src/utils/generateDoc.ts
+++ b/src/utils/generateDoc.ts
@@ -6,6 +6,22 @@ const formatRands = (amount: number): string =>
 export interface InvoiceData {
   clientInfo: { name: string; email: string; address: string; phone: string };
   invoiceDetails: { invoiceNumber: string; invoiceDate: string; dueDate: string };
+  companyInfo: {
+    name: string;
+    tagline: string;
+    email: string;
+    address: string;
+    phone: string;
+    website: string;
+    regNo: string;
+    vatNo: string;
+  };
+  bankingDetails: {
+    bankName: string;
+    accountNumber: string;
+    branchCode: string;
+    payShapCell: string;
+  };
   services: { description: string; date: string; quantity: number; unitPrice: number; discount: number; total: number }[];
   tax: number;
   notes: string;
@@ -14,23 +30,24 @@ export interface InvoiceData {
 }
 
 function buildInvoicePDF(data: InvoiceData): jsPDF {
-  const { clientInfo, invoiceDetails, services, tax, notes, subtotal, grandTotal } = data;
+  const {
+    clientInfo,
+    invoiceDetails,
+    companyInfo,
+    bankingDetails,
+    services,
+    tax,
+    notes,
+    subtotal,
+    grandTotal,
+  } = data;
   const doc = new jsPDF();
   const pageWidth = 210;
   const margin = 15;
   const contentWidth = pageWidth - margin * 2;
   const amountColRight = margin + contentWidth;
 
-  const company = {
-    name: 'JE Productions',
-    tagline: 'Professional Digital Solutions',
-    email: 'abeljackson33@gmail.com',
-    address: 'Modimolle, Limpopo, South Africa',
-    phone: '+27 62 677 5823',
-    website: 'www.aj4200.dev',
-    regNo: '---',
-    vatNo: '---',
-  };
+  const company = companyInfo;
 
   const colors = {
     primary: [15, 23, 42] as [number, number, number],
@@ -261,13 +278,13 @@ function buildInvoicePDF(data: InvoiceData): jsPDF {
   doc.setFont('helvetica', 'normal');
   doc.setTextColor(...colors.secondary);
   doc.text('Bank Transfer (EFT)', margin + 8, currentY + 22);
-  doc.text('Bank: Capitec', margin + 8, currentY + 28);
-  doc.text('Account Number: 1534094529', margin + 8, currentY + 34);
-  doc.text('Branch Code: 470010', margin + 8, currentY + 40);
+  doc.text(`Bank: ${bankingDetails.bankName || '—'}`, margin + 8, currentY + 28);
+  doc.text(`Account Number: ${bankingDetails.accountNumber || '—'}`, margin + 8, currentY + 34);
+  doc.text(`Branch Code: ${bankingDetails.branchCode || '—'}`, margin + 8, currentY + 40);
   doc.text('Reference: Inv #' + invoiceDetails.invoiceNumber, margin + 8, currentY + 46);
 
   doc.text('PayShap', margin + 110, currentY + 22);
-  doc.text('Cell: 062 677 5823', margin + 110, currentY + 28);
+  doc.text(`Cell: ${bankingDetails.payShapCell || '—'}`, margin + 110, currentY + 28);
 
   currentY += 60;
 


### PR DESCRIPTION
### Motivation
- Replace hardcoded sender/company and payment information so users can edit company and banking details manually before generating or emailing invoices.
- Ensure the PDF and outgoing email reflect the user-provided company and banking data instead of static defaults.

### Description
- Added `companyInfo` and `bankingDetails` state, input handlers, and UI sections in `src/components/InvoiceForm.tsx` and wired those values into the form workflow.
- Extended the `InvoiceData` type and `buildInvoicePDF` in `src/utils/generateDoc.ts` to accept `companyInfo` and `bankingDetails`, and replaced hardcoded company and bank strings with those values.
- Updated `src/app/api/send-invoice/route.ts` to accept an optional `companyName` from the client payload and use a fallback chain (`payload -> env -> default`) for the email subject/body.

### Testing
- Ran TypeScript checks with `npx tsc --noEmit` which succeeded.
- Attempted `npm run lint` but it prompted Next.js ESLint interactive setup, so lint could not be completed non-interactively.
- Attempted `npm run build` which failed in this environment due to Next.js failing to fetch the Google `Inter` font (network/font fetch issue), so production build could not be verified here.
- Started the dev server with `npm run dev` successfully for manual UI verification, and attempted an automated Playwright screenshot which failed due to a Chromium runtime crash in the container (SIGSEGV).
