### PR TITLE
Add Neon auth portal and multi-currency groundwork

### DIFF
--- a/docs/neon-google-client-portal.md
+++ b/docs/neon-google-client-portal.md
@@ -1,0 +1,26 @@
+# Neon, Google auth, currencies, and client portal implementation plan
+
+## Environment
+
+- `DATABASE_URL`: Neon PostgreSQL pooled connection string.
+- `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET`: Google OAuth credentials.
+- `NEXTAUTH_SECRET` / `NEXTAUTH_URL`: session encryption and callback URL.
+- Payment provider credentials for Stripe, PayPal, or an Open Payments-compatible provider.
+
+## Login and business provisioning
+
+Use Google OAuth for business users. After a successful login, run an idempotent provisioning step: find the user's `Business` record by `ownerId`; if it does not exist, create it using the Google profile name/email and default currency.
+
+## Client portal
+
+Clients should have a secure portal to:
+
+- View invoices by paid/unpaid status.
+- Download stored invoice PDFs.
+- Pay outstanding invoices online.
+- Use bank details as an alternative payment method when online payments are not available.
+- View payment history over time.
+
+## International currency support
+
+Businesses store a default currency, while every invoice stores its own invoice currency, business currency, and exchange rate snapshot. Amounts should always be formatted with `Intl.NumberFormat` for the invoice currency, and exchange rates should be displayed when the invoice currency differs from the business default.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,166 @@
+// Neon PostgreSQL schema for Invoico.
+// Set DATABASE_URL to your Neon pooled connection string.
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id            String    @id @default(cuid())
+  name          String?
+  email         String    @unique
+  emailVerified DateTime?
+  image         String?
+  accounts      Account[]
+  sessions      Session[]
+  business      Business?
+  clientProfile Client?
+  createdAt     DateTime  @default(now())
+  updatedAt     DateTime  @updatedAt
+}
+
+model Account {
+  id                String  @id @default(cuid())
+  userId            String
+  type              String
+  provider          String
+  providerAccountId String
+  refresh_token     String?
+  access_token      String?
+  expires_at        Int?
+  token_type        String?
+  scope             String?
+  id_token          String?
+  session_state     String?
+  user              User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([provider, providerAccountId])
+}
+
+model Session {
+  id           String   @id @default(cuid())
+  sessionToken String   @unique
+  userId       String
+  expires      DateTime
+  user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+}
+
+model VerificationToken {
+  identifier String
+  token      String   @unique
+  expires    DateTime
+
+  @@unique([identifier, token])
+}
+
+model Business {
+  id              String    @id @default(cuid())
+  ownerId         String    @unique
+  owner           User      @relation(fields: [ownerId], references: [id], onDelete: Cascade)
+  name            String
+  defaultCurrency String    @default("ZAR")
+  email           String?
+  address         String?
+  phone           String?
+  website         String?
+  bankName        String?
+  accountNumber   String?
+  branchCode      String?
+  payShapCell     String?
+  invoices        Invoice[]
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
+}
+
+model Client {
+  id             String    @id @default(cuid())
+  userId         String?   @unique
+  user           User?     @relation(fields: [userId], references: [id], onDelete: SetNull)
+  businessId     String
+  name           String
+  email          String
+  address        String?
+  phone          String?
+  invoices       Invoice[]
+  payments       Payment[]
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
+}
+
+model Invoice {
+  id               String        @id @default(cuid())
+  businessId       String
+  business         Business      @relation(fields: [businessId], references: [id], onDelete: Cascade)
+  clientId         String
+  client           Client        @relation(fields: [clientId], references: [id], onDelete: Cascade)
+  invoiceNumber    String
+  status           InvoiceStatus @default(UNPAID)
+  invoiceDate      DateTime
+  dueDate          DateTime
+  currency         String
+  businessCurrency String
+  exchangeRate     Decimal       @default(1)
+  subtotal         Decimal
+  tax              Decimal       @default(0)
+  total            Decimal
+  pdfUrl           String?
+  lineItems        InvoiceLineItem[]
+  payments         Payment[]
+  createdAt        DateTime      @default(now())
+  updatedAt        DateTime      @updatedAt
+
+  @@unique([businessId, invoiceNumber])
+}
+
+model InvoiceLineItem {
+  id          String  @id @default(cuid())
+  invoiceId   String
+  invoice     Invoice @relation(fields: [invoiceId], references: [id], onDelete: Cascade)
+  description String
+  serviceDate DateTime?
+  quantity    Decimal @default(1)
+  unitPrice   Decimal
+  discount    Decimal @default(0)
+  total       Decimal
+}
+
+model Payment {
+  id              String        @id @default(cuid())
+  invoiceId       String
+  invoice         Invoice       @relation(fields: [invoiceId], references: [id], onDelete: Cascade)
+  clientId        String
+  client          Client        @relation(fields: [clientId], references: [id], onDelete: Cascade)
+  provider        PaymentProvider
+  providerRef     String?
+  amount          Decimal
+  currency        String
+  status          PaymentStatus @default(PENDING)
+  paidAt          DateTime?
+  createdAt       DateTime      @default(now())
+}
+
+enum InvoiceStatus {
+  UNPAID
+  PARTIALLY_PAID
+  PAID
+  VOID
+}
+
+enum PaymentProvider {
+  STRIPE
+  PAYPAL
+  OPEN_PAYMENTS
+  BANK_TRANSFER
+  MANUAL
+}
+
+enum PaymentStatus {
+  PENDING
+  SUCCEEDED
+  FAILED
+  REFUNDED
+}

--- a/src/components/InvoiceForm.tsx
+++ b/src/components/InvoiceForm.tsx
@@ -25,12 +25,16 @@ import {
   Hash,
   Landmark,
   CreditCard,
+  LockKeyhole,
+  History,
+  Wallet,
 } from 'lucide-react';
 import { Card } from './ui/Card';
 import { Input } from './ui/Input';
 import { Button } from './ui/Button';
 import { ServiceItem } from './ServiceItem';
 import { generatePDF, generatePDFAsBase64 } from '@/utils/generateDoc';
+import { formatExchangeRate, formatMoney, SUPPORTED_CURRENCIES } from '@/utils/currency';
 import { Loader } from './ui/Loader';
 
 interface Service {
@@ -249,6 +253,9 @@ export default function InvoiceForm() {
 
   const [tax, setTax] = useState(0);
   const [notes, setNotes] = useState('');
+  const [businessCurrency, setBusinessCurrency] = useState('ZAR');
+  const [invoiceCurrency, setInvoiceCurrency] = useState('ZAR');
+  const [exchangeRate, setExchangeRate] = useState(1);
 
   const [recurrence, setRecurrence] = useState<RecurrenceSettings>(() => {
     const today = new Date().toISOString().slice(0, 10);
@@ -708,6 +715,9 @@ export default function InvoiceForm() {
       notes,
       subtotal: calculateSubtotal(),
       grandTotal: calculateGrandTotal(),
+      currency: invoiceCurrency,
+      businessCurrency,
+      exchangeRate,
     });
 
     await new Promise((resolve) => setTimeout(resolve, 500));
@@ -739,6 +749,9 @@ export default function InvoiceForm() {
         notes,
         subtotal: calculateSubtotal(),
         grandTotal: calculateGrandTotal(),
+        currency: invoiceCurrency,
+        businessCurrency,
+        exchangeRate,
       });
 
       setIsGenerating(false);
@@ -790,6 +803,35 @@ export default function InvoiceForm() {
             Professional invoices in minutes
           </p>
         </motion.div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
+          <Card variant="elevated" className="p-6">
+            <div className="flex items-start gap-4">
+              <div className="w-11 h-11 bg-sky-100 dark:bg-sky-900/50 rounded-xl flex items-center justify-center">
+                <LockKeyhole className="w-5 h-5 text-sky-600 dark:text-sky-400" />
+              </div>
+              <div>
+                <h2 className="text-xl font-bold text-stone-800 dark:text-stone-100">Google business login</h2>
+                <p className="text-sm text-stone-600 dark:text-stone-400 mt-1">
+                  Planned for NextAuth Google OAuth backed by Neon PostgreSQL. A business profile is created after first Google login when one does not already exist.
+                </p>
+              </div>
+            </div>
+          </Card>
+          <Card variant="elevated" className="p-6">
+            <div className="flex items-start gap-4">
+              <div className="w-11 h-11 bg-emerald-100 dark:bg-emerald-900/40 rounded-xl flex items-center justify-center">
+                <Wallet className="w-5 h-5 text-emerald-600 dark:text-emerald-400" />
+              </div>
+              <div>
+                <h2 className="text-xl font-bold text-stone-800 dark:text-stone-100">Secure client portal</h2>
+                <p className="text-sm text-stone-600 dark:text-stone-400 mt-1">
+                  Clients can view paid/unpaid invoices, download PDFs, see payment history, pay online through Stripe/PayPal/Open Payments-compatible providers, or use displayed bank details.
+                </p>
+              </div>
+            </div>
+          </Card>
+        </div>
 
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
           <div className="lg:col-span-2 space-y-6">
@@ -1081,7 +1123,7 @@ export default function InvoiceForm() {
 
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <Input
-                  label="Tax (R)"
+                  label={`Tax (${invoiceCurrency})`}
                   type="number"
                   value={tax}
                   onChange={(e) => setTax(parseFloat(e.target.value) || 0)}
@@ -1091,6 +1133,45 @@ export default function InvoiceForm() {
                   icon={<Banknote className="w-4 h-4" />}
                 />
               </div>
+
+              <div className="mt-6 grid grid-cols-1 md:grid-cols-3 gap-4">
+                <div>
+                  <label className="block text-sm font-medium text-stone-700 dark:text-stone-300 mb-1.5">
+                    Default Business Currency
+                  </label>
+                  <select className={selectStyles} value={businessCurrency} onChange={(e) => setBusinessCurrency(e.target.value)}>
+                    {SUPPORTED_CURRENCIES.map((currency) => (
+                      <option key={currency.code} value={currency.code}>
+                        {currency.code} — {currency.name}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-stone-700 dark:text-stone-300 mb-1.5">
+                    Invoice Currency
+                  </label>
+                  <select className={selectStyles} value={invoiceCurrency} onChange={(e) => setInvoiceCurrency(e.target.value)}>
+                    {SUPPORTED_CURRENCIES.map((currency) => (
+                      <option key={currency.code} value={currency.code}>
+                        {currency.code} — {currency.name}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <Input
+                  label="Exchange Rate"
+                  type="number"
+                  value={exchangeRate}
+                  onChange={(e) => setExchangeRate(parseFloat(e.target.value) || 1)}
+                  min="0.000001"
+                  step="0.000001"
+                  icon={<Globe className="w-4 h-4" />}
+                />
+              </div>
+              <p className="mt-2 text-xs text-stone-500 dark:text-stone-400">
+                {businessCurrency === invoiceCurrency ? 'No exchange rate needed.' : formatExchangeRate(exchangeRate, businessCurrency, invoiceCurrency)}
+              </p>
 
               <div className="mt-4">
                 <label className="block text-sm font-medium text-stone-700 dark:text-stone-300 mb-1.5">
@@ -1393,7 +1474,7 @@ export default function InvoiceForm() {
                       </div>
                       <div className="text-right">
                         <p className="font-semibold text-stone-800 dark:text-stone-100">
-                          R {invoice.total.toLocaleString('en-ZA', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                          {formatMoney(invoice.total, invoiceCurrency)}
                         </p>
                         <p className="text-xs text-stone-500 dark:text-stone-400">
                           Due {invoice.dueDate}
@@ -1406,7 +1487,16 @@ export default function InvoiceForm() {
             </Card>
           </div>
 
-          <div className="lg:col-span-1">
+          <div className="lg:col-span-1 space-y-6">
+            <Card variant="elevated" className="p-6">
+              <h3 className="text-xl font-bold text-stone-800 dark:text-stone-100 mb-4">Client Portal Preview</h3>
+              <div className="space-y-3 text-sm text-stone-600 dark:text-stone-400">
+                <p className="flex items-center gap-2"><FileCheck className="w-4 h-4 text-sky-500" /> Paid and unpaid invoice list</p>
+                <p className="flex items-center gap-2"><Download className="w-4 h-4 text-sky-500" /> PDF download for every invoice</p>
+                <p className="flex items-center gap-2"><CreditCard className="w-4 h-4 text-sky-500" /> Online payments plus banking details fallback</p>
+                <p className="flex items-center gap-2"><History className="w-4 h-4 text-sky-500" /> Payment history over time</p>
+              </div>
+            </Card>
             <Card variant="elevated" className="p-8 sticky top-8">
               <h3 className="text-2xl font-bold text-stone-800 dark:text-stone-100 mb-6">Summary</h3>
 
@@ -1414,14 +1504,14 @@ export default function InvoiceForm() {
                 <div className="flex justify-between items-center pb-3 border-b border-stone-200 dark:border-stone-700">
                   <span className="text-stone-600 dark:text-stone-400">Subtotal</span>
                   <span className="text-lg font-semibold text-stone-800 dark:text-stone-100">
-                    R {calculateSubtotal().toLocaleString('en-ZA', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                    {formatMoney(calculateSubtotal(), invoiceCurrency)}
                   </span>
                 </div>
 
                 <div className="flex justify-between items-center pb-3 border-b border-stone-200 dark:border-stone-700">
                   <span className="text-stone-600 dark:text-stone-400">Tax</span>
                   <span className="text-lg font-semibold text-green-600 dark:text-green-400">
-                    +R {tax.toLocaleString('en-ZA', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                    +{formatMoney(tax, invoiceCurrency)}
                   </span>
                 </div>
 
@@ -1432,7 +1522,7 @@ export default function InvoiceForm() {
                 >
                   <p className="text-sm opacity-90 mb-2">Total Amount Due</p>
                   <p className="text-4xl font-bold">
-                    R {calculateGrandTotal().toLocaleString('en-ZA', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                    {formatMoney(calculateGrandTotal(), invoiceCurrency)}
                   </p>
                 </motion.div>
               </div>

--- a/src/lib/auth-plan.ts
+++ b/src/lib/auth-plan.ts
@@ -1,0 +1,9 @@
+export const authPlan = {
+  database: 'Neon PostgreSQL via DATABASE_URL',
+  provider: 'Google OAuth',
+  firstLoginProvisioning:
+    'After a Google login, create a Business row for the user if one does not already exist.',
+  clientPortal:
+    'Clients authenticate, then view invoice status, download PDFs, pay online, or use bank details.',
+  paymentOptions: ['Stripe', 'PayPal', 'Open Payments-compatible providers', 'Bank transfer'],
+};

--- a/src/utils/currency.ts
+++ b/src/utils/currency.ts
@@ -1,0 +1,30 @@
+export const SUPPORTED_CURRENCIES = [
+  { code: 'ZAR', name: 'South African Rand', locale: 'en-ZA' },
+  { code: 'USD', name: 'US Dollar', locale: 'en-US' },
+  { code: 'EUR', name: 'Euro', locale: 'de-DE' },
+  { code: 'GBP', name: 'British Pound', locale: 'en-GB' },
+  { code: 'NGN', name: 'Nigerian Naira', locale: 'en-NG' },
+  { code: 'KES', name: 'Kenyan Shilling', locale: 'en-KE' },
+  { code: 'INR', name: 'Indian Rupee', locale: 'en-IN' },
+] as const;
+
+export type CurrencyCode = (typeof SUPPORTED_CURRENCIES)[number]['code'];
+
+export const getCurrency = (code: string) =>
+  SUPPORTED_CURRENCIES.find((currency) => currency.code === code) ?? SUPPORTED_CURRENCIES[0];
+
+export const formatMoney = (amount: number, currencyCode: string) => {
+  const currency = getCurrency(currencyCode);
+
+  return new Intl.NumberFormat(currency.locale, {
+    style: 'currency',
+    currency: currency.code,
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(Number.isFinite(amount) ? amount : 0);
+};
+
+export const formatExchangeRate = (rate: number, fromCurrency: string, toCurrency: string) =>
+  `1 ${fromCurrency} = ${new Intl.NumberFormat(getCurrency(toCurrency).locale, {
+    maximumFractionDigits: 6,
+  }).format(Number.isFinite(rate) && rate > 0 ? rate : 1)} ${toCurrency}`;

--- a/src/utils/generateDoc.ts
+++ b/src/utils/generateDoc.ts
@@ -1,7 +1,5 @@
 import { jsPDF } from 'jspdf';
-
-const formatRands = (amount: number): string =>
-  `R ${amount.toLocaleString('en-ZA', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+import { formatExchangeRate, formatMoney, getCurrency } from './currency';
 
 export interface InvoiceData {
   clientInfo: { name: string; email: string; address: string; phone: string };
@@ -25,6 +23,9 @@ export interface InvoiceData {
   services: { description: string; date: string; quantity: number; unitPrice: number; discount: number; total: number }[];
   tax: number;
   notes: string;
+  currency: string;
+  businessCurrency: string;
+  exchangeRate: number;
   subtotal: number;
   grandTotal: number;
 }
@@ -40,6 +41,9 @@ function buildInvoicePDF(data: InvoiceData): jsPDF {
     notes,
     subtotal,
     grandTotal,
+    currency,
+    businessCurrency,
+    exchangeRate,
   } = data;
   const doc = new jsPDF();
   const pageWidth = 210;
@@ -48,6 +52,8 @@ function buildInvoicePDF(data: InvoiceData): jsPDF {
   const amountColRight = margin + contentWidth;
 
   const company = companyInfo;
+  const invoiceCurrency = getCurrency(currency);
+  const currencyLabel = `${invoiceCurrency.code} (${invoiceCurrency.name})`;
 
   const colors = {
     primary: [15, 23, 42] as [number, number, number],
@@ -148,7 +154,7 @@ function buildInvoicePDF(data: InvoiceData): jsPDF {
   doc.setTextColor(...colors.secondary);
   doc.text(invoiceDetails.invoiceDate, margin + 8, currentY + 18);
   doc.text(invoiceDetails.dueDate, margin + 65, currentY + 18);
-  doc.text('ZAR (South African Rand)', margin + 122, currentY + 18);
+  doc.text(currencyLabel, margin + 122, currentY + 18);
 
   currentY += 38;
 
@@ -201,13 +207,13 @@ function buildInvoicePDF(data: InvoiceData): jsPDF {
     doc.text(descLines, margin + 4, currentY + 4);
     doc.text(service.date || '—', margin + 82, currentY + 4);
     doc.text(service.quantity.toString(), margin + 100, currentY + 4);
-    doc.text(formatRands(service.unitPrice), margin + 115, currentY + 4);
+    doc.text(formatMoney(service.unitPrice, currency), margin + 115, currentY + 4);
     const discount = service.discount ?? 0;
     doc.setTextColor(...(discount > 0 ? colors.discount : colors.dark));
-    doc.text(formatRands(discount), margin + 140, currentY + 4);
+    doc.text(formatMoney(discount, currency), margin + 140, currentY + 4);
     doc.setTextColor(...colors.dark);
     doc.setFont('helvetica', 'bold');
-    doc.text(formatRands(service.total), amountColRight, currentY + 4, { align: 'right' });
+    doc.text(formatMoney(service.total, currency), amountColRight, currentY + 4, { align: 'right' });
     doc.setFont('helvetica', 'normal');
 
     const lineHeight = Math.max(descLines.length * 5, 10);
@@ -225,12 +231,12 @@ function buildInvoicePDF(data: InvoiceData): jsPDF {
   doc.setFontSize(10);
   doc.setFont('helvetica', 'normal');
   doc.text('Subtotal', margin + 130, currentY);
-  doc.text(formatRands(subtotal), amountColRight, currentY, { align: 'right' });
+  doc.text(formatMoney(subtotal, currency), amountColRight, currentY, { align: 'right' });
   currentY += 8;
 
   doc.text('Tax (VAT)', margin + 130, currentY);
   doc.setTextColor(...colors.success);
-  doc.text(`+ ${formatRands(tax)}`, amountColRight, currentY, { align: 'right' });
+  doc.text(`+ ${formatMoney(tax, currency)}`, amountColRight, currentY, { align: 'right' });
   doc.setTextColor(...colors.dark);
   currentY += 14;
 
@@ -240,7 +246,7 @@ function buildInvoicePDF(data: InvoiceData): jsPDF {
   doc.setFontSize(12);
   doc.setFont('helvetica', 'bold');
   doc.text('Amount Due', margin + 110, currentY + 2);
-  doc.text(formatRands(grandTotal), amountColRight, currentY + 2, { align: 'right' });
+  doc.text(formatMoney(grandTotal, currency), amountColRight, currentY + 2, { align: 'right' });
 
   currentY += 24;
 
@@ -285,6 +291,10 @@ function buildInvoicePDF(data: InvoiceData): jsPDF {
 
   doc.text('PayShap', margin + 110, currentY + 22);
   doc.text(`Cell: ${bankingDetails.payShapCell || '—'}`, margin + 110, currentY + 28);
+  if (currency !== businessCurrency) {
+    doc.text('Exchange Rate', margin + 110, currentY + 38);
+    doc.text(formatExchangeRate(exchangeRate, businessCurrency, currency), margin + 110, currentY + 44);
+  }
 
   currentY += 60;
 
@@ -304,7 +314,7 @@ function buildInvoicePDF(data: InvoiceData): jsPDF {
   doc.setTextColor(...colors.secondary);
   const terms = [
     '• Payment is due within the specified due date. Late payments may incur interest.',
-    '• All amounts are in South African Rand (ZAR) unless otherwise stated.',
+    `• All amounts are in ${invoiceCurrency.name} (${invoiceCurrency.code}) unless otherwise stated.`,
     '• Please use the invoice number as your payment reference.',
     '• VAT is included where applicable. Tax invoice available on request.',
   ];


### PR DESCRIPTION
### Motivation
- Prepare the app for Neon PostgreSQL-backed user/business storage and Google OAuth login with automatic business provisioning on first sign-in.
- Add multi-currency support so businesses can set a default currency, invoices can use per-invoice currencies, and exchange-rate snapshots are recorded and displayed.
- Surface a secure client-portal concept in the UI and plan for payment provider integration so clients can view/download/pay invoices.

### Description
- Added a Prisma schema targeting Neon/Postgres with `User`, `Account`, `Session`, `Business`, `Client`, `Invoice`, `InvoiceLineItem`, and `Payment` models plus enums for statuses and providers at `prisma/schema.prisma` to support Google OAuth users, business provisioning, invoices, and payments.
- Added currency helpers in `src/utils/currency.ts` including `SUPPORTED_CURRENCIES`, `formatMoney`, `getCurrency`, and `formatExchangeRate` for locale-aware formatting and exchange-rate display.
- Updated PDF generation in `src/utils/generateDoc.ts` to accept `currency`, `businessCurrency`, and `exchangeRate`, to format all amounts with `formatMoney`, show the invoice currency label, and include exchange-rate info when currencies differ.
- Updated `src/components/InvoiceForm.tsx` to expose UI for default business currency, per-invoice currency, exchange-rate input, and client-portal / Google-login preview cards, and to pass currency metadata into PDF/email generation; also added `src/lib/auth-plan.ts` and `docs/neon-google-client-portal.md` with an implementation plan.

### Testing
- `npx tsc --noEmit` completed successfully with no type errors.
- `npm run build` was attempted but failed due to the environment being unable to fetch the Google `Inter` font used by `next/font` (network/font fetch issue), so a production build could not be completed in this environment.
- Dev server / screenshot automation was attempted but could not complete because Playwright is not installed in the environment, so visual verification was not produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d3c7fd52c8325ae791fa5f5aa85b4)